### PR TITLE
handle no comments on first import

### DIFF
--- a/packages/gatsby-codemods/src/transforms/global-graphql-calls.js
+++ b/packages/gatsby-codemods/src/transforms/global-graphql-calls.js
@@ -33,7 +33,10 @@ function addEsmImport(j, root, tag) {
 
   if (!existingImport.length) {
     const first = root.find(j.Program).get(`body`, 0)
-    const comments = first.node.comments.splice(0)
+    let comments
+    if(first.node.comments){
+      comments = first.node.comments.splice(0)
+    }
     const importStatement = j.importDeclaration(
       [j.importSpecifier(j.identifier(IMPORT_NAME))],
       j.literal(MODULE_NAME)


### PR DESCRIPTION
<!--
  Have any questions? Check out the contributing docs at https://gatsby.app/contribute, or
  ask in this Pull Request and a Gatsby maintainer will be happy to help :)
-->

## Description

the current transformer assumes that the first import has at least one comment, which causes the script to crash if there's not any.

bug example
https://astexplorer.net/#/gist/4349f731d25ac09b8e381f1061416347/f9b6cebb9f0b3090306f46eebd781c35bba1b21d

fix example
https://astexplorer.net/#/gist/aa3e3e64646ce0d25a912f3422c5bde0/8601961b91739582bfe78b6e620466994ce3a86d


## Related Issues

caught this while was upgrading to v2